### PR TITLE
BUGFIX/MAJOR(ecd): Add maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ An Ansible role for install and configure ECD. Specifically, the responsibilitie
 | `openio_ecd_volume` | `/var/lib/oio/sds/{{ openio_ecd_namespace }}/{{ openio_ecd_servicename }}"` | Path to store data |
 | `openio_ecd_wsgi_processes` | `{{ ansible_processor_vcpus }}` | Defines the number of daemon processes that should be started in this process group |
 | `openio_ecd_wsgi_threads` | `1` | Defines the number of threads to be created to handle requests in each daemon process within the process group |
+| `openio_ecd_provision_only` | `false` | Provision only without restarting / bootstrapping |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,4 +23,5 @@ openio_ecd_version: 'latest'
 
 openio_ecd_wsgi_processes: "{{ ansible_processor_vcpus }}"
 openio_ecd_wsgi_threads: 1
+openio_ecd_provision_only: false
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,6 +72,8 @@
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart  {{openio_ecd_namespace}}-{{openio_ecd_servicename}}
-  when: _ecd_conf.changed
+  when:
+    - _ecd_conf.changed
+    - not openio_ecd_provision_only
   tags: configure
 ...


### PR DESCRIPTION
 ##### SUMMARY

Lack of maintenance mode in ecd delivery --> restart services and reload gridinit even if openio_maintenance_mode is set to true

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION