### PR TITLE
CHANGE(ecd): Ensure service is started or restarted at the end of role

### DIFF
--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -4,14 +4,12 @@
   become: true
   vars:
     NS: TRAVIS
+    openio_bootstrap: true
   roles:
     - role: users
     - role: repo
-      openio_repository_openstack_release: 'queens'
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
+      openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_per_ns: true
       openio_gridinit_namespace: "{{ NS }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,12 +68,37 @@
     group: openio
     mode: 0644
 
-- name: restart ecd
+- name: "restart ecd to apply the new configuration"
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart  {{openio_ecd_namespace}}-{{openio_ecd_servicename}}
+  register: _restart_ecd
   when:
-    - _ecd_conf.changed
+    - _ecd_conf is changed
     - not openio_ecd_provision_only
   tags: configure
+
+- block:
+    - name: "Ensure ecd is started"
+      command: gridinit_cmd start {{ openio_ecd_namespace }}-{{ openio_ecd_servicename }}
+      register: _start_ecd
+      changed_when: '"Success" in _start_ecd.stdout'
+      when:
+        - not openio_ecd_provision_only
+        - _restart_ecd is skipped
+      tags: configure
+
+    - name: check ecd
+      uri:
+        url: "http://{{ openio_ecd_bind_address }}:{{ openio_ecd_bind_port }}"
+        method: HEAD
+        status_code: 403
+      register: _ecd_check
+      retries: 3
+      delay: 5
+      until: _ecd_check is success
+      changed_when: false
+      when:
+        - not openio_ecd_provision_only
+  when: openio_bootstrap | d(false)
 ...


### PR DESCRIPTION
 ##### SUMMARY
Until 18.10, a voluntarily stopped service was not revived by a reproviosionning.

In 19.04, the `maintenance` mode becomes the default mode.

To avoid having to force (ie. deletion of conf files) the restart of a service delivered first, by error, in maintenance mode: We have to make sure that service is started and it works well at the end of the role.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION