### PR TITLE
BUGFIX/MINOR(ecd): Limit the number of workers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ openio_ecd_socket_directory: "/run/oio/sds/{{ openio_ecd_namespace }}/{{ openio_
 
 openio_ecd_version: 'latest'
 
-openio_ecd_wsgi_processes: "{{ ansible_processor_vcpus }}"
+openio_ecd_wsgi_processes: "{{ [(ansible_processor_vcpus | int ), 10] | min }}"
 openio_ecd_wsgi_threads: 1
 openio_ecd_provision_only: false
 ...


### PR DESCRIPTION
 ##### SUMMARY

When the system have 80 `ansible_processor_vcpus`, it's ridiculous to deploy an ECD with 80 workers.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION