### PR TITLE
CHANGE(ecd): Set the bind_interface to openio_bind_interface by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 openio_ecd_namespace: "{{ namespace | default('OPENIO') }}"
 openio_ecd_serviceid: "{{ 0 + openio_legacy_serviceid | d(0) | int }}"
 
-openio_ecd_bind_interface: "{{ ansible_default_ipv4.alias }}"
+openio_ecd_bind_interface: "{{ openio_bind_interface | d(ansible_default_ipv4.alias) }}"
 openio_ecd_bind_address:
   "{{ openio_bind_address \
     | default(hostvars[inventory_hostname]['ansible_' + openio_ecd_bind_interface]['ipv4']['address']) }}"


### PR DESCRIPTION
 ##### SUMMARY

As bind_address, a good default is openio_bind_interface

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION